### PR TITLE
Fix broken GitHub project cards

### DIFF
--- a/about/_projects.qmd
+++ b/about/_projects.qmd
@@ -1,19 +1,17 @@
 
-::: {.callout-tip icon=false aria-title="GitHub Repos" title='[📂 [`ishanpragada/`](https://github.com/saforem2?tab=repositories)]{.dim-text-11}' collapse="false" style="text-align: left!important; width:100%; background-color:rgba(131,131,131,0.05)!important; border: 1px solid rgba(131,131,131,0.3)!important; opacity:100%;"}
+::: {.callout-tip icon=false aria-title="GitHub Repos" title='[📂 [`ishanpragada/`](https://github.com/ishanpragada?tab=repositories)]{.dim-text-11}' collapse="false" style="text-align: left!important; width:100%; background-color:rgba(131,131,131,0.05)!important; border: 1px solid rgba(131,131,131,0.3)!important; opacity:100%;"}
 
 ::: {.flex-container style="flex-flow: wrap;"}
 
-[![](https://github-readme-stats.vercel.app/api/pin/?username=appfl&repo=appfl&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383)](https://github.com/appfl/appfl)
+[![](https://gh-card.dev/repos/ishanpragada/dlp_model.svg)](https://github.com/ishanpragada/dlp_model)
 
-[![](https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=dlp_model&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383)](https://github.com/ishanpragada/dlp_model)
+[![](https://gh-card.dev/repos/ishanpragada/asr_system.svg)](https://github.com/ishanpragada/asr_system)
 
-[![](https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=asr_system&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383)](https://github.com/ishanpragada/asr_system)
+[![](https://gh-card.dev/repos/ishanpragada/alexa_gpt.svg)](https://github.com/ishanpragada/alexa_gpt)
 
-[![](https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=alexa_gpt&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383)](https://github.com/ishanpragada/alexa_gpt)
+[![](https://gh-card.dev/repos/ishanpragada/ragaID.svg)](https://github.com/ishanpragada/ragaID)
 
-[![](https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=ragaID&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383)](https://github.com/ishanpragada/ragaID)
-
-[![](https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=portfolio_website&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383)](https://github.com/ishanpragada/portfolio_website)
+[![](https://gh-card.dev/repos/ishanpragada/portfolio_website.svg)](https://github.com/ishanpragada/portfolio_website)
 :::
 
 :::

--- a/qmd/partials/_projects.qmd
+++ b/qmd/partials/_projects.qmd
@@ -1,19 +1,17 @@
 
-::: {.callout-tip icon=false aria-title="GitHub Repos" title='[📂 [`ishanpragada/`](https://github.com/saforem2?tab=repositories)]{.dim-text-11}' collapse="false" style="text-align: left!important; width:100%; background-color:rgba(131,131,131,0.05)!important; border: 1px solid rgba(131,131,131,0.3)!important; opacity:100%;"}
+::: {.callout-tip icon=false aria-title="GitHub Repos" title='[📂 [`ishanpragada/`](https://github.com/ishanpragada?tab=repositories)]{.dim-text-11}' collapse="false" style="text-align: left!important; width:100%; background-color:rgba(131,131,131,0.05)!important; border: 1px solid rgba(131,131,131,0.3)!important; opacity:100%;"}
 
 ::: {.flex-container style="flex-flow: wrap;"}
 
-[![](https://github-readme-stats.vercel.app/api/pin/?username=appfl&repo=appfl&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383)](https://github.com/appfl/appfl)
+[![](https://gh-card.dev/repos/ishanpragada/dlp_model.svg)](https://github.com/ishanpragada/dlp_model)
 
-[![](https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=dlp_model&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383)](https://github.com/ishanpragada/dlp_model)
+[![](https://gh-card.dev/repos/ishanpragada/asr_system.svg)](https://github.com/ishanpragada/asr_system)
 
-[![](https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=asr_system&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383)](https://github.com/ishanpragada/asr_system)
+[![](https://gh-card.dev/repos/ishanpragada/alexa_gpt.svg)](https://github.com/ishanpragada/alexa_gpt)
 
-[![](https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=alexa_gpt&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383)](https://github.com/ishanpragada/alexa_gpt)
+[![](https://gh-card.dev/repos/ishanpragada/ragaID.svg)](https://github.com/ishanpragada/ragaID)
 
-[![](https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=ragaID&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383)](https://github.com/ishanpragada/ragaID)
-
-[![](https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=portfolio_website&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383)](https://github.com/ishanpragada/portfolio_website)
+[![](https://gh-card.dev/repos/ishanpragada/portfolio_website.svg)](https://github.com/ishanpragada/portfolio_website)
 :::
 
 :::


### PR DESCRIPTION
## Summary

- The `github-readme-stats.vercel.app` public deployment is permanently paused (`DEPLOYMENT_PAUSED` 503), causing all project card images to fail. Switched to `gh-card.dev` which returns valid SVGs.
- Removed a stray `appfl/appfl` repo card that belonged to a different user (leftover from template).
- Fixed the callout title link that incorrectly pointed to `github.com/saforem2` instead of `github.com/ishanpragada`.

## Test plan

- [x] Verify project cards render correctly on the home page projects section
- [x] Verify project cards render correctly on the standalone `/projects` page