### PR TITLE
Redesign GitHub project cards with dynamic flex grid

### DIFF
--- a/about/_projects.qmd
+++ b/about/_projects.qmd
@@ -1,17 +1,243 @@
 
 ::: {.callout-tip icon=false aria-title="GitHub Repos" title='[📂 [`ishanpragada/`](https://github.com/ishanpragada?tab=repositories)]{.dim-text-11}' collapse="false" style="text-align: left!important; width:100%; background-color:rgba(131,131,131,0.05)!important; border: 1px solid rgba(131,131,131,0.3)!important; opacity:100%;"}
 
-::: {.flex-container style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;"}
+<style>
+  .repo-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 0.5rem;
+    padding-bottom: 0;
+  }
 
-[![](https://gh-card.dev/repos/ishanpragada/dlp_model.svg?theme=dark)](https://github.com/ishanpragada/dlp_model)
+  /* invisible spacer prevents the lone last card from stretching */
+  .repo-grid::after {
+    content: "";
+    flex: 1 1 260px;
+    max-width: 360px;
+    height: 0;
+    overflow: hidden;
+  }
 
-[![](https://gh-card.dev/repos/ishanpragada/asr_system.svg?theme=dark)](https://github.com/ishanpragada/asr_system)
+  .repo-card {
+    flex: 1 1 260px;
+    max-width: 360px;
+    border-radius: 0pt;
+    padding: 1rem 1.1rem 1.5rem;
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    background-color: var(--bs-body-bg, #ffffff);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.15s ease, box-shadow 0.15s ease,
+                border-color 0.15s ease, background-color 0.15s ease;
+    font-family: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
+  }
 
-[![](https://gh-card.dev/repos/ishanpragada/alexa_gpt.svg?theme=dark)](https://github.com/ishanpragada/alexa_gpt)
+  .repo-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 3pt 3pt #AE81FF;
+  }
 
-[![](https://gh-card.dev/repos/ishanpragada/ragaID.svg?theme=dark)](https://github.com/ishanpragada/ragaID)
+  .repo-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.4rem;
+    margin-bottom: 0.35rem;
+  }
 
-[![](https://gh-card.dev/repos/ishanpragada/portfolio_website.svg?theme=dark)](https://github.com/ishanpragada/portfolio_website)
-:::
+  .repo-name {
+    color: inherit;
+    background: none;
+    font-size: 1.0rem;
+    font-weight: 600;
+    margin: 0;
+    word-break: break-word;
+    border: 1pt solid rgba(0,0,0,0.0) !important;
+    padding-inline: 1pt;
+  }
+
+  .repo-name a {
+    text-decoration: none;
+    color: var(--bs-link-color, #0d6efd);
+  }
+
+  .repo-name a:hover {
+    text-decoration: underline;
+    border: none;
+  }
+
+  .repo-badge {
+    font-size: 0.7rem;
+    padding: 0.15rem 0.45rem;
+    border: 1px solid var(--bs-border-color, #838383);
+    background: var(--bs-secondary-bg, rgba(108, 117, 125, 0.1));
+    white-space: nowrap;
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  .repo-description {
+    font-size: 0.9rem;
+    margin: 0.3rem 0 0.6rem;
+    color: var(--bs-secondary-color, #6c757d);
+    min-height: 2.2em;
+  }
+
+  .repo-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: auto;
+    font-size: 0.8rem;
+    color: var(--bs-secondary-color, #6c757d);
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  .repo-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+  }
+
+  .repo-language-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    background: currentColor;
+  }
+
+  body.quarto-dark .repo-card {
+    background-color: var(--bs-body-bg, #1c1c1c);
+    border-color: var(--bs-border-color, #374151);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.6);
+  }
+
+  body.quarto-dark .repo-card:hover {
+    box-shadow: 3pt 3pt var(--bs-secondary-color, #838383);
+  }
+
+  body.quarto-dark .repo-badge {
+    background: #2a2a2a !important;
+    color: #f0f0f0 !important;
+    border-color: #555555 !important;
+  }
+
+  .repo-grid-loading {
+    font-size: 0.9rem;
+    color: var(--bs-secondary-color, #6c757d);
+    margin-top: 0.75rem;
+    font-family: "IBM Plex Mono", monospace;
+  }
+</style>
+
+<p class="repo-grid-loading" id="repo-grid-status">
+  Loading repositories from GitHub…
+</p>
+<div id="repo-grid"
+     class="repo-grid"
+     data-github-user="ishanpragada">
+</div>
+
+<script>
+  (async function () {
+    const grid = document.getElementById("repo-grid");
+    const status = document.getElementById("repo-grid-status");
+    if (!grid) return;
+
+    const username = grid.getAttribute("data-github-user") || "ishanpragada";
+    const apiUrl = `https://api.github.com/users/${username}/repos?per_page=100&sort=updated`;
+
+    try {
+      const res = await fetch(apiUrl);
+      if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
+      const repos = await res.json();
+
+      const filtered = repos.filter(r => !r.fork);
+
+      if (filtered.length === 0) {
+        if (status) status.textContent = "No repositories found.";
+        return;
+      }
+      if (status) status.remove();
+
+      function formatNumber(n) {
+        if (n >= 1_000_000) return (n / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
+        if (n >= 1_000) return (n / 1_000).toFixed(1).replace(/\.0$/, "") + "k";
+        return String(n);
+      }
+
+      filtered.forEach(repo => {
+        const card = document.createElement("div");
+        card.className = "repo-card";
+
+        const header = document.createElement("div");
+        header.className = "repo-header";
+
+        const title = document.createElement("h3");
+        title.className = "repo-name";
+        const link = document.createElement("a");
+        link.href = repo.html_url;
+        link.textContent = repo.name;
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
+        title.appendChild(link);
+
+        const badge = document.createElement("span");
+        badge.className = "repo-badge";
+        badge.textContent = repo.private ? "Private" : "Public";
+
+        header.appendChild(title);
+        header.appendChild(badge);
+
+        const desc = document.createElement("p");
+        desc.className = "repo-description";
+        desc.textContent = repo.description || "No description provided.";
+
+        const meta = document.createElement("div");
+        meta.className = "repo-meta";
+
+        if (repo.language) {
+          const langSpan = document.createElement("span");
+          const dot = document.createElement("span");
+          dot.className = "repo-language-dot";
+          langSpan.appendChild(dot);
+          const langText = document.createElement("span");
+          langText.textContent = repo.language;
+          langSpan.appendChild(langText);
+          meta.appendChild(langSpan);
+        }
+
+        const starsSpan = document.createElement("span");
+        starsSpan.innerHTML = "⭐️ " + formatNumber(repo.stargazers_count || 0);
+        meta.appendChild(starsSpan);
+
+        const updatedSpan = document.createElement("span");
+        const updatedDate = new Date(repo.updated_at);
+        updatedSpan.textContent = "Updated " + updatedDate.toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric"
+        });
+        meta.appendChild(updatedSpan);
+
+        card.appendChild(header);
+        card.appendChild(desc);
+        card.appendChild(meta);
+        grid.appendChild(card);
+      });
+
+      // Force bottom spacing via inline styles (bypasses CSS specificity issues)
+      grid.style.paddingBottom = "0.25rem";
+      const lastCard = grid.querySelector(".repo-card:last-child");
+      if (lastCard) lastCard.style.paddingBottom = "1.5rem";
+    } catch (err) {
+      console.error(err);
+      if (status) {
+        status.textContent = "Failed to load repositories from GitHub.";
+      }
+    }
+  })();
+</script>
 
 :::

--- a/about/_projects.qmd
+++ b/about/_projects.qmd
@@ -1,17 +1,17 @@
 
 ::: {.callout-tip icon=false aria-title="GitHub Repos" title='[📂 [`ishanpragada/`](https://github.com/ishanpragada?tab=repositories)]{.dim-text-11}' collapse="false" style="text-align: left!important; width:100%; background-color:rgba(131,131,131,0.05)!important; border: 1px solid rgba(131,131,131,0.3)!important; opacity:100%;"}
 
-::: {.flex-container style="flex-flow: wrap;"}
+::: {.flex-container style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;"}
 
-[![](https://gh-card.dev/repos/ishanpragada/dlp_model.svg)](https://github.com/ishanpragada/dlp_model)
+[![](https://gh-card.dev/repos/ishanpragada/dlp_model.svg?theme=dark)](https://github.com/ishanpragada/dlp_model)
 
-[![](https://gh-card.dev/repos/ishanpragada/asr_system.svg)](https://github.com/ishanpragada/asr_system)
+[![](https://gh-card.dev/repos/ishanpragada/asr_system.svg?theme=dark)](https://github.com/ishanpragada/asr_system)
 
-[![](https://gh-card.dev/repos/ishanpragada/alexa_gpt.svg)](https://github.com/ishanpragada/alexa_gpt)
+[![](https://gh-card.dev/repos/ishanpragada/alexa_gpt.svg?theme=dark)](https://github.com/ishanpragada/alexa_gpt)
 
-[![](https://gh-card.dev/repos/ishanpragada/ragaID.svg)](https://github.com/ishanpragada/ragaID)
+[![](https://gh-card.dev/repos/ishanpragada/ragaID.svg?theme=dark)](https://github.com/ishanpragada/ragaID)
 
-[![](https://gh-card.dev/repos/ishanpragada/portfolio_website.svg)](https://github.com/ishanpragada/portfolio_website)
+[![](https://gh-card.dev/repos/ishanpragada/portfolio_website.svg?theme=dark)](https://github.com/ishanpragada/portfolio_website)
 :::
 
 :::

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 Ishan Buyyanapragada
-2025-01-27
+2026-04-16
 
 <div style="font-size:1.0em; text-align: center;">
 
@@ -37,10 +37,10 @@ style="width: 100%; justify-content: space-between; align-items: flex-start;">
 
 <div class="column">
 
-- computer science student @ [UIUC]
+- incoming sde intern @ [AWS] · cs @ [UIUC]
 - currently interested in:
-  - building sustainable solutions to everyday problems using
-    [disruptive] technologies.
+  - systems programming, performance engineering, and low-latency
+    execution on Linux.
   - identifying and addressing [health infodemics].
 
 </div>
@@ -163,21 +163,212 @@ style="width: 100%; justify-content: space-between; align-items: flex-start;">
 >
 > ### <span class="dim-text-11">📂 [`ishanpragada/`]</span>
 >
-> <div class="flex-container" style="flex-flow: wrap;">
+> <style>
+>   .repo-grid {
+>     display: flex;
+>     flex-wrap: wrap;
+>     gap: 1rem;
+>     margin-top: 0.5rem;
+>     padding-bottom: 0;
+>   }
+> &#10;  /* invisible spacer prevents the lone last card from stretching */
+>   .repo-grid::after {
+>     content: "";
+>     flex: 1 1 260px;
+>     max-width: 360px;
+>     height: 0;
+>     overflow: hidden;
+>   }
+> &#10;  .repo-card {
+>     flex: 1 1 260px;
+>     max-width: 360px;
+>     border-radius: 0pt;
+>     padding: 1rem 1.1rem 1.5rem;
+>     border: 1px solid var(--bs-border-color, #dee2e6);
+>     background-color: var(--bs-body-bg, #ffffff);
+>     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+>     display: flex;
+>     flex-direction: column;
+>     transition: transform 0.15s ease, box-shadow 0.15s ease,
+>                 border-color 0.15s ease, background-color 0.15s ease;
+>     font-family: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
+>   }
+> &#10;  .repo-card:hover {
+>     transform: translateY(-3px);
+>     box-shadow: 3pt 3pt #AE81FF;
+>   }
+> &#10;  .repo-header {
+>     display: flex;
+>     align-items: center;
+>     justify-content: space-between;
+>     gap: 0.4rem;
+>     margin-bottom: 0.35rem;
+>   }
+> &#10;  .repo-name {
+>     color: inherit;
+>     background: none;
+>     font-size: 1.0rem;
+>     font-weight: 600;
+>     margin: 0;
+>     word-break: break-word;
+>     border: 1pt solid rgba(0,0,0,0.0) !important;
+>     padding-inline: 1pt;
+>   }
+> &#10;  .repo-name a {
+>     text-decoration: none;
+>     color: var(--bs-link-color, #0d6efd);
+>   }
+> &#10;  .repo-name a:hover {
+>     text-decoration: underline;
+>     border: none;
+>   }
+> &#10;  .repo-badge {
+>     font-size: 0.7rem;
+>     padding: 0.15rem 0.45rem;
+>     border: 1px solid var(--bs-border-color, #838383);
+>     background: var(--bs-secondary-bg, rgba(108, 117, 125, 0.1));
+>     white-space: nowrap;
+>     font-family: "IBM Plex Mono", monospace;
+>   }
+> &#10;  .repo-description {
+>     font-size: 0.9rem;
+>     margin: 0.3rem 0 0.6rem;
+>     color: var(--bs-secondary-color, #6c757d);
+>     min-height: 2.2em;
+>   }
+> &#10;  .repo-meta {
+>     display: flex;
+>     flex-wrap: wrap;
+>     align-items: center;
+>     gap: 0.6rem;
+>     margin-top: auto;
+>     font-size: 0.8rem;
+>     color: var(--bs-secondary-color, #6c757d);
+>     font-family: "IBM Plex Mono", monospace;
+>   }
+> &#10;  .repo-meta span {
+>     display: inline-flex;
+>     align-items: center;
+>     gap: 0.2rem;
+>   }
+> &#10;  .repo-language-dot {
+>     width: 0.55rem;
+>     height: 0.55rem;
+>     background: currentColor;
+>   }
+> &#10;  body.quarto-dark .repo-card {
+>     background-color: var(--bs-body-bg, #1c1c1c);
+>     border-color: var(--bs-border-color, #374151);
+>     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.6);
+>   }
+> &#10;  body.quarto-dark .repo-card:hover {
+>     box-shadow: 3pt 3pt var(--bs-secondary-color, #838383);
+>   }
+> &#10;  body.quarto-dark .repo-badge {
+>     background: #2a2a2a !important;
+>     color: #f0f0f0 !important;
+>     border-color: #555555 !important;
+>   }
+> &#10;  .repo-grid-loading {
+>     font-size: 0.9rem;
+>     color: var(--bs-secondary-color, #6c757d);
+>     margin-top: 0.75rem;
+>     font-family: "IBM Plex Mono", monospace;
+>   }
+> </style>
 >
-> [![][18]][19]
+> <p class="repo-grid-loading" id="repo-grid-status">
 >
-> [![][20]][21]
+> Loading repositories from GitHub…
+> </p>
 >
-> [![][22]][23]
->
-> [![][24]][25]
->
-> [![][26]][27]
->
-> [![][28]][29]
+> <div id="repo-grid" class="repo-grid" data-github-user="ishanpragada">
 >
 > </div>
+>
+> <script>
+>   (async function () {
+>     const grid = document.getElementById("repo-grid");
+>     const status = document.getElementById("repo-grid-status");
+>     if (!grid) return;
+> &#10;    const username = grid.getAttribute("data-github-user") || "ishanpragada";
+>     const apiUrl = `https://api.github.com/users/${username}/repos?per_page=100&sort=updated`;
+> &#10;    try {
+>       const res = await fetch(apiUrl);
+>       if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
+>       const repos = await res.json();
+> &#10;      const filtered = repos.filter(r => !r.fork);
+> &#10;      if (filtered.length === 0) {
+>         if (status) status.textContent = "No repositories found.";
+>         return;
+>       }
+>       if (status) status.remove();
+> &#10;      function formatNumber(n) {
+>         if (n >= 1_000_000) return (n / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
+>         if (n >= 1_000) return (n / 1_000).toFixed(1).replace(/\.0$/, "") + "k";
+>         return String(n);
+>       }
+> &#10;      filtered.forEach(repo => {
+>         const card = document.createElement("div");
+>         card.className = "repo-card";
+> &#10;        const header = document.createElement("div");
+>         header.className = "repo-header";
+> &#10;        const title = document.createElement("h3");
+>         title.className = "repo-name";
+>         const link = document.createElement("a");
+>         link.href = repo.html_url;
+>         link.textContent = repo.name;
+>         link.target = "_blank";
+>         link.rel = "noopener noreferrer";
+>         title.appendChild(link);
+> &#10;        const badge = document.createElement("span");
+>         badge.className = "repo-badge";
+>         badge.textContent = repo.private ? "Private" : "Public";
+> &#10;        header.appendChild(title);
+>         header.appendChild(badge);
+> &#10;        const desc = document.createElement("p");
+>         desc.className = "repo-description";
+>         desc.textContent = repo.description || "No description provided.";
+> &#10;        const meta = document.createElement("div");
+>         meta.className = "repo-meta";
+> &#10;        if (repo.language) {
+>           const langSpan = document.createElement("span");
+>           const dot = document.createElement("span");
+>           dot.className = "repo-language-dot";
+>           langSpan.appendChild(dot);
+>           const langText = document.createElement("span");
+>           langText.textContent = repo.language;
+>           langSpan.appendChild(langText);
+>           meta.appendChild(langSpan);
+>         }
+> &#10;        const starsSpan = document.createElement("span");
+>         starsSpan.innerHTML = "⭐️ " + formatNumber(repo.stargazers_count || 0);
+>         meta.appendChild(starsSpan);
+> &#10;        const updatedSpan = document.createElement("span");
+>         const updatedDate = new Date(repo.updated_at);
+>         updatedSpan.textContent = "Updated " + updatedDate.toLocaleDateString(undefined, {
+>           year: "numeric",
+>           month: "short",
+>           day: "numeric"
+>         });
+>         meta.appendChild(updatedSpan);
+> &#10;        card.appendChild(header);
+>         card.appendChild(desc);
+>         card.appendChild(meta);
+>         grid.appendChild(card);
+>       });
+> &#10;      // Force bottom spacing via inline styles (bypasses CSS specificity issues)
+>       grid.style.paddingBottom = "0.25rem";
+>       const lastCard = grid.querySelector(".repo-card:last-child");
+>       if (lastCard) lastCard.style.paddingBottom = "1.5rem";
+>     } catch (err) {
+>       console.error(err);
+>       if (status) {
+>         status.textContent = "Failed to load repositories from GitHub.";
+>       }
+>     }
+>   })();
+> </script>
 
 </div>
 
@@ -189,12 +380,13 @@ style="width: 100%; justify-content: space-between; align-items: flex-start;">
 
 Table 1: 💻 work
 
-| position                    |              @               | start | end  |
-|:----------------------------|:----------------------------:|:-----:|:----:|
-| software engineering intern |        [ANB Systems]         | 2024  |  –   |
-| software developer          | [Disruption Lab][disruptive] | 2024  |  –   |
-| research intern             |            [ALCF]            | 2023  | 2024 |
-| CELS research assistant     |            [ANL]             | 2021  | 2023 |
+| position | @ | start | end |
+|:---|:--:|:--:|:--:|
+| software development engineering intern | [Amazon Web Services][AWS] | 2026 | – |
+| systems operations engineer | [Tandemn] | 2025 | – |
+| SPIN intern | [NCSA] | 2025 | 2025 |
+| software engineering intern | [ANB Systems] | 2024 | 2024 |
+| CELS research intern | [ANL] | 2022 | 2024 |
 
 </div>
 
@@ -204,9 +396,9 @@ Table 1: 💻 work
 
 Table 2: 🎓 education
 
-| degree |         in         |     @      | end  |
-|:-------|:------------------:|:----------:|:----:|
-| B.Sc   | [Computer Science] | [UIUC][30] | 2027 |
+| degree               |         in         |     @      | end  |
+|:---------------------|:------------------:|:----------:|:----:|
+| B.Sc (James Scholar) | [Computer Science] | [UIUC][18] | 2028 |
 
 </div>
 
@@ -224,7 +416,7 @@ Table 2: 🎓 education
   [5]: mailto:///ibuyy@illinois.edu
   [6]: https://open.spotify.com/user/ishanpragada
   [7]: https://calendly.com/ishanpragada/30min
-  [disruptive]: https://giesbusiness.illinois.edu/disruption-lab
+  [AWS]: https://aws.amazon.com/
   [health infodemics]: https://ischool.illinois.edu/news-events/news/2023/04/virtual-center-addresses-health-infodemics
   [8]: https://spotify-github-profile.kittinanx.com/api/view?uid=ishanpragada&cover_image=true&theme=natemoo-re&show_offline=false&background_color=000000&interchange=true&bar_color=53b14f&bar_color_cover=true.png
   [9]: https://spotify-github-profile.kittinanx.com/api/view?uid=ishanpragada&redirect=true
@@ -236,21 +428,10 @@ Table 2: 🎓 education
   [15]: assets/dorm%20(1).jpg
   [16]: assets/grad%20(1).jpg
   [17]: assets/arang.jpeg
-  [`ishanpragada/`]: https://github.com/saforem2?tab=repositories
-  [18]: https://github-readme-stats.vercel.app/api/pin/?username=appfl&repo=appfl&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383.png
-  [19]: https://github.com/appfl/appfl
-  [20]: https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=dlp_model&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383.png
-  [21]: https://github.com/ishanpragada/dlp_model
-  [22]: https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=asr_system&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383.png
-  [23]: https://github.com/ishanpragada/asr_system
-  [24]: https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=alexa_gpt&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383.png
-  [25]: https://github.com/ishanpragada/alexa_gpt
-  [26]: https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=ragaID&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383.png
-  [27]: https://github.com/ishanpragada/ragaID
-  [28]: https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&repo=portfolio_website&theme=transparent&include_all_commits=true&hide_border=true&line_height=5&card_width=300px&text_color=838383&title_color=838383.png
-  [29]: https://github.com/ishanpragada/portfolio_website
+  [`ishanpragada/`]: https://github.com/ishanpragada?tab=repositories
+  [Tandemn]: https://www.tandemn.com/
+  [NCSA]: https://ncsa.illinois.edu/
   [ANB Systems]: https://www.anbsystems.com/
-  [ALCF]: https://alcf.anl.gov
   [ANL]: https://www.anl.gov/
   [Computer Science]: https://grainger.illinois.edu/academics/undergraduate/majors-and-minors/computer-science
-  [30]: https://illinois.edu/
+  [18]: https://illinois.edu/

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 <meta name="author" content="Ishan Buyyanapragada">
-<meta name="dcterms.date" content="2025-01-27">
+<meta name="dcterms.date" content="2026-04-16">
 
 <title>Ishan’s Portfolio</title>
 <style>
@@ -40,8 +40,8 @@ ul.task-list li input[type="checkbox"] {
 <link href="site_libs/quarto-html/tippy.css" rel="stylesheet">
 <script src="site_libs/bootstrap/bootstrap.min.js"></script>
 <link href="site_libs/bootstrap/bootstrap-icons.css" rel="stylesheet">
-<link href="site_libs/bootstrap/bootstrap-634274a65c934703ca25721b58038b96.min.css" rel="stylesheet" append-hash="true" class="quarto-color-scheme" id="quarto-bootstrap" data-mode="light">
-<link href="site_libs/bootstrap/bootstrap-dark-375d3df8afcba5abed17207adbcd21f6.min.css" rel="prefetch" append-hash="true" class="quarto-color-scheme quarto-color-alternate" id="quarto-bootstrap" data-mode="dark">
+<link href="site_libs/bootstrap/bootstrap-d2106b212eb76b55cd8cda3724386f96.min.css" rel="stylesheet" append-hash="true" class="quarto-color-scheme" id="quarto-bootstrap" data-mode="light">
+<link href="site_libs/bootstrap/bootstrap-dark-cc2076eef7a103a60f2d4c6c3c1e31d6.min.css" rel="prefetch" append-hash="true" class="quarto-color-scheme quarto-color-alternate" id="quarto-bootstrap" data-mode="dark">
 <script src="site_libs/quarto-contrib/iconify-2.1.0/iconify-icon.min.js"></script>
 <script src="site_libs/quarto-contrib/glightbox/glightbox.min.js"></script>
 <link href="site_libs/quarto-contrib/glightbox/glightbox.min.css" rel="stylesheet">
@@ -71,9 +71,7 @@ ul.task-list li input[type="checkbox"] {
     "search-label": "Search"
   }
 }</script>
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TC329HJ');</script>
-<!-- End Google Tag Manager -->
+
 <link href="https://iosevka-webfonts.github.io/iosevkatermss15/IosevkaTermSS15.css" rel="stylesheet">
 
 
@@ -84,10 +82,10 @@ ul.task-list li input[type="checkbox"] {
 <meta property="og:image" content="">
 <meta property="og:site_name" content="Ishan's Portfolio">
 <meta name="citation_author" content="Ishan Buyyanapragada">
-<meta name="citation_publication_date" content="2025-01-27">
-<meta name="citation_cover_date" content="2025-01-27">
-<meta name="citation_year" content="2025">
-<meta name="citation_online_date" content="2025-01-27">
+<meta name="citation_publication_date" content="2026-04-16">
+<meta name="citation_cover_date" content="2026-04-16">
+<meta name="citation_year" content="2026">
+<meta name="citation_online_date" content="2026-04-16">
 <meta name="citation_fulltext_html_url" content="https://ishankr.com/">
 <meta name="citation_language" content="en">
 <meta name="citation_reference" content="citation_title=Superconductivity of in and sn samples;,citation_author=George Deamont;,citation_author=Sam Foreman;,citation_publication_date=2014;,citation_cover_date=2014;,citation_year=2014;">
@@ -250,7 +248,7 @@ ul.task-list li input[type="checkbox"] {
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">January 27, 2025</p>
+      <p class="date">April 16, 2026</p>
     </div>
   </div>
   
@@ -276,10 +274,10 @@ ul.task-list li input[type="checkbox"] {
 <div class="flex-container" style="width: 100%; justify-content: space-between; align-items: flex-start;">
 <div class="column">
 <ul>
-<li>computer science student @ <a href="https://illinois.edu">UIUC</a></li>
+<li>incoming sde intern @ <a href="https://aws.amazon.com/">AWS</a> · cs @ <a href="https://illinois.edu">UIUC</a></li>
 <li>currently interested in:
 <ul>
-<li>building sustainable solutions to everyday problems using <a href="https://giesbusiness.illinois.edu/disruption-lab">disruptive</a> technologies.</li>
+<li>systems programming, performance engineering, and low-latency execution on Linux.</li>
 <li>identifying and addressing <a href="https://ischool.illinois.edu/news-events/news/2023/04/virtual-center-addresses-health-infodemics">health infodemics</a>.</li>
 </ul></li>
 </ul>
@@ -413,26 +411,253 @@ ul.task-list li input[type="checkbox"] {
 </div>
 <div id="tabset-1-2" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-2-tab">
 <div style="a:hover {text-decoration: none!important; color: none!important;}">
-<div class="callout callout-style-simple callout-tip no-icon callout-titled" aria-title="GitHub Repos" title="[📂 [`ishanpragada/`](https://github.com/saforem2?tab=repositories)]{.dim-text-11}" style="text-align: left!important; width:100%; background-color:rgba(131,131,131,0.05)!important; border: 1px solid rgba(131,131,131,0.3)!important; opacity:100%;">
+<div class="callout callout-style-simple callout-tip no-icon callout-titled" aria-title="GitHub Repos" title="[📂 [`ishanpragada/`](https://github.com/ishanpragada?tab=repositories)]{.dim-text-11}" style="text-align: left!important; width:100%; background-color:rgba(131,131,131,0.05)!important; border: 1px solid rgba(131,131,131,0.3)!important; opacity:100%;">
 <div class="callout-header d-flex align-content-center" data-bs-toggle="collapse" data-bs-target=".callout-4-contents" aria-controls="callout-4" aria-expanded="true" aria-label="Toggle callout">
 <div class="callout-icon-container">
 <i class="callout-icon no-icon"></i>
 </div>
 <div class="callout-title-container flex-fill">
-<span class="dim-text-11">📂 <a href="https://github.com/saforem2?tab=repositories"><code>ishanpragada/</code></a></span>
+<span class="dim-text-11">📂 <a href="https://github.com/ishanpragada?tab=repositories"><code>ishanpragada/</code></a></span>
 </div>
 <div class="callout-btn-toggle d-inline-block border-0 py-1 ps-1 pe-0 float-end"><i class="callout-toggle"></i></div>
 </div>
 <div id="callout-4" class="callout-4-contents callout-collapse collapse show">
 <div class="callout-body-container callout-body">
-<div class="flex-container" style="flex-flow: wrap;">
-<p><a href="https://github.com/appfl/appfl"><img src="https://github-readme-stats.vercel.app/api/pin/?username=appfl&amp;repo=appfl&amp;theme=transparent&amp;include_all_commits=true&amp;hide_border=true&amp;line_height=5&amp;card_width=300px&amp;text_color=838383&amp;title_color=838383.svg" class="img-fluid"></a></p>
-<p><a href="https://github.com/ishanpragada/dlp_model"><img src="https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&amp;repo=dlp_model&amp;theme=transparent&amp;include_all_commits=true&amp;hide_border=true&amp;line_height=5&amp;card_width=300px&amp;text_color=838383&amp;title_color=838383.svg" class="img-fluid"></a></p>
-<p><a href="https://github.com/ishanpragada/asr_system"><img src="https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&amp;repo=asr_system&amp;theme=transparent&amp;include_all_commits=true&amp;hide_border=true&amp;line_height=5&amp;card_width=300px&amp;text_color=838383&amp;title_color=838383.svg" class="img-fluid"></a></p>
-<p><a href="https://github.com/ishanpragada/alexa_gpt"><img src="https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&amp;repo=alexa_gpt&amp;theme=transparent&amp;include_all_commits=true&amp;hide_border=true&amp;line_height=5&amp;card_width=300px&amp;text_color=838383&amp;title_color=838383.svg" class="img-fluid"></a></p>
-<p><a href="https://github.com/ishanpragada/ragaID"><img src="https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&amp;repo=ragaID&amp;theme=transparent&amp;include_all_commits=true&amp;hide_border=true&amp;line_height=5&amp;card_width=300px&amp;text_color=838383&amp;title_color=838383.svg" class="img-fluid"></a></p>
-<p><a href="https://github.com/ishanpragada/portfolio_website"><img src="https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&amp;repo=portfolio_website&amp;theme=transparent&amp;include_all_commits=true&amp;hide_border=true&amp;line_height=5&amp;card_width=300px&amp;text_color=838383&amp;title_color=838383.svg" class="img-fluid"></a></p>
+<style>
+  .repo-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 0.5rem;
+    padding-bottom: 0;
+  }
+
+  /* invisible spacer prevents the lone last card from stretching */
+  .repo-grid::after {
+    content: "";
+    flex: 1 1 260px;
+    max-width: 360px;
+    height: 0;
+    overflow: hidden;
+  }
+
+  .repo-card {
+    flex: 1 1 260px;
+    max-width: 360px;
+    border-radius: 0pt;
+    padding: 1rem 1.1rem 1.5rem;
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    background-color: var(--bs-body-bg, #ffffff);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.15s ease, box-shadow 0.15s ease,
+                border-color 0.15s ease, background-color 0.15s ease;
+    font-family: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
+  }
+
+  .repo-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 3pt 3pt #AE81FF;
+  }
+
+  .repo-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.4rem;
+    margin-bottom: 0.35rem;
+  }
+
+  .repo-name {
+    color: inherit;
+    background: none;
+    font-size: 1.0rem;
+    font-weight: 600;
+    margin: 0;
+    word-break: break-word;
+    border: 1pt solid rgba(0,0,0,0.0) !important;
+    padding-inline: 1pt;
+  }
+
+  .repo-name a {
+    text-decoration: none;
+    color: var(--bs-link-color, #0d6efd);
+  }
+
+  .repo-name a:hover {
+    text-decoration: underline;
+    border: none;
+  }
+
+  .repo-badge {
+    font-size: 0.7rem;
+    padding: 0.15rem 0.45rem;
+    border: 1px solid var(--bs-border-color, #838383);
+    background: var(--bs-secondary-bg, rgba(108, 117, 125, 0.1));
+    white-space: nowrap;
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  .repo-description {
+    font-size: 0.9rem;
+    margin: 0.3rem 0 0.6rem;
+    color: var(--bs-secondary-color, #6c757d);
+    min-height: 2.2em;
+  }
+
+  .repo-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: auto;
+    font-size: 0.8rem;
+    color: var(--bs-secondary-color, #6c757d);
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  .repo-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+  }
+
+  .repo-language-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    background: currentColor;
+  }
+
+  body.quarto-dark .repo-card {
+    background-color: var(--bs-body-bg, #1c1c1c);
+    border-color: var(--bs-border-color, #374151);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.6);
+  }
+
+  body.quarto-dark .repo-card:hover {
+    box-shadow: 3pt 3pt var(--bs-secondary-color, #838383);
+  }
+
+  body.quarto-dark .repo-badge {
+    background: #2a2a2a !important;
+    color: #f0f0f0 !important;
+    border-color: #555555 !important;
+  }
+
+  .repo-grid-loading {
+    font-size: 0.9rem;
+    color: var(--bs-secondary-color, #6c757d);
+    margin-top: 0.75rem;
+    font-family: "IBM Plex Mono", monospace;
+  }
+</style>
+<p class="repo-grid-loading" id="repo-grid-status">
+Loading repositories from GitHub…
+</p>
+<div id="repo-grid" class="repo-grid" data-github-user="ishanpragada">
+
 </div>
+<script>
+  (async function () {
+    const grid = document.getElementById("repo-grid");
+    const status = document.getElementById("repo-grid-status");
+    if (!grid) return;
+
+    const username = grid.getAttribute("data-github-user") || "ishanpragada";
+    const apiUrl = `https://api.github.com/users/${username}/repos?per_page=100&sort=updated`;
+
+    try {
+      const res = await fetch(apiUrl);
+      if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
+      const repos = await res.json();
+
+      const filtered = repos.filter(r => !r.fork);
+
+      if (filtered.length === 0) {
+        if (status) status.textContent = "No repositories found.";
+        return;
+      }
+      if (status) status.remove();
+
+      function formatNumber(n) {
+        if (n >= 1_000_000) return (n / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
+        if (n >= 1_000) return (n / 1_000).toFixed(1).replace(/\.0$/, "") + "k";
+        return String(n);
+      }
+
+      filtered.forEach(repo => {
+        const card = document.createElement("div");
+        card.className = "repo-card";
+
+        const header = document.createElement("div");
+        header.className = "repo-header";
+
+        const title = document.createElement("h3");
+        title.className = "repo-name";
+        const link = document.createElement("a");
+        link.href = repo.html_url;
+        link.textContent = repo.name;
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
+        title.appendChild(link);
+
+        const badge = document.createElement("span");
+        badge.className = "repo-badge";
+        badge.textContent = repo.private ? "Private" : "Public";
+
+        header.appendChild(title);
+        header.appendChild(badge);
+
+        const desc = document.createElement("p");
+        desc.className = "repo-description";
+        desc.textContent = repo.description || "No description provided.";
+
+        const meta = document.createElement("div");
+        meta.className = "repo-meta";
+
+        if (repo.language) {
+          const langSpan = document.createElement("span");
+          const dot = document.createElement("span");
+          dot.className = "repo-language-dot";
+          langSpan.appendChild(dot);
+          const langText = document.createElement("span");
+          langText.textContent = repo.language;
+          langSpan.appendChild(langText);
+          meta.appendChild(langSpan);
+        }
+
+        const starsSpan = document.createElement("span");
+        starsSpan.innerHTML = "⭐️ " + formatNumber(repo.stargazers_count || 0);
+        meta.appendChild(starsSpan);
+
+        const updatedSpan = document.createElement("span");
+        const updatedDate = new Date(repo.updated_at);
+        updatedSpan.textContent = "Updated " + updatedDate.toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric"
+        });
+        meta.appendChild(updatedSpan);
+
+        card.appendChild(header);
+        card.appendChild(desc);
+        card.appendChild(meta);
+        grid.appendChild(card);
+      });
+
+      // Force bottom spacing via inline styles (bypasses CSS specificity issues)
+      grid.style.paddingBottom = "0.25rem";
+      const lastCard = grid.querySelector(".repo-card:last-child");
+      if (lastCard) lastCard.style.paddingBottom = "1.5rem";
+    } catch (err) {
+      console.error(err);
+      if (status) {
+        status.textContent = "Failed to load repositories from GitHub.";
+      }
+    }
+  })();
+</script>
 </div>
 </div>
 </div>
@@ -459,28 +684,34 @@ Table&nbsp;1: 💻 work
 </thead>
 <tbody>
 <tr class="odd">
-<td style="text-align: left;">software engineering intern</td>
-<td style="text-align: center;"><a href="https://www.anbsystems.com/">ANB Systems</a></td>
-<td style="text-align: center;">2024</td>
+<td style="text-align: left;">software development engineering intern</td>
+<td style="text-align: center;"><a href="https://aws.amazon.com/">Amazon Web Services</a></td>
+<td style="text-align: center;">2026</td>
 <td style="text-align: center;">–</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">software developer</td>
-<td style="text-align: center;"><a href="https://giesbusiness.illinois.edu/disruption-lab">Disruption Lab</a></td>
-<td style="text-align: center;">2024</td>
+<td style="text-align: left;">systems operations engineer</td>
+<td style="text-align: center;"><a href="https://www.tandemn.com/">Tandemn</a></td>
+<td style="text-align: center;">2025</td>
 <td style="text-align: center;">–</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">research intern</td>
-<td style="text-align: center;"><a href="https://alcf.anl.gov">ALCF</a></td>
-<td style="text-align: center;">2023</td>
-<td style="text-align: center;">2024</td>
+<td style="text-align: left;">SPIN intern</td>
+<td style="text-align: center;"><a href="https://ncsa.illinois.edu/">NCSA</a></td>
+<td style="text-align: center;">2025</td>
+<td style="text-align: center;">2025</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">CELS research assistant</td>
+<td style="text-align: left;">software engineering intern</td>
+<td style="text-align: center;"><a href="https://www.anbsystems.com/">ANB Systems</a></td>
+<td style="text-align: center;">2024</td>
+<td style="text-align: center;">2024</td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">CELS research intern</td>
 <td style="text-align: center;"><a href="https://www.anl.gov/">ANL</a></td>
-<td style="text-align: center;">2021</td>
-<td style="text-align: center;">2023</td>
+<td style="text-align: center;">2022</td>
+<td style="text-align: center;">2024</td>
 </tr>
 </tbody>
 </table>
@@ -509,10 +740,10 @@ Table&nbsp;2: 🎓 education
 </thead>
 <tbody>
 <tr class="odd">
-<td style="text-align: left;">B.Sc</td>
+<td style="text-align: left;">B.Sc (James Scholar)</td>
 <td style="text-align: center;"><a href="https://grainger.illinois.edu/academics/undergraduate/majors-and-minors/computer-science">Computer Science</a></td>
 <td style="text-align: center;"><a href="https://illinois.edu/">UIUC</a></td>
-<td style="text-align: center;">2027</td>
+<td style="text-align: center;">2028</td>
 </tr>
 </tbody>
 </table>

--- a/docs/listings.json
+++ b/docs/listings.json
@@ -2,6 +2,7 @@
   {
     "listing": "/posts/index.html",
     "items": [
+      "/posts/on-ai/index.html",
       "/posts/is-this-thing-on/index.html"
     ]
   }

--- a/docs/posts/index.html
+++ b/docs/posts/index.html
@@ -75,8 +75,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <link href="../site_libs/quarto-html/tippy.css" rel="stylesheet">
 <script src="../site_libs/bootstrap/bootstrap.min.js"></script>
 <link href="../site_libs/bootstrap/bootstrap-icons.css" rel="stylesheet">
-<link href="../site_libs/bootstrap/bootstrap-634274a65c934703ca25721b58038b96.min.css" rel="stylesheet" append-hash="true" class="quarto-color-scheme" id="quarto-bootstrap" data-mode="light">
-<link href="../site_libs/bootstrap/bootstrap-dark-375d3df8afcba5abed17207adbcd21f6.min.css" rel="prefetch" append-hash="true" class="quarto-color-scheme quarto-color-alternate" id="quarto-bootstrap" data-mode="dark">
+<link href="../site_libs/bootstrap/bootstrap-d2106b212eb76b55cd8cda3724386f96.min.css" rel="stylesheet" append-hash="true" class="quarto-color-scheme" id="quarto-bootstrap" data-mode="light">
+<link href="../site_libs/bootstrap/bootstrap-dark-cc2076eef7a103a60f2d4c6c3c1e31d6.min.css" rel="prefetch" append-hash="true" class="quarto-color-scheme quarto-color-alternate" id="quarto-bootstrap" data-mode="dark">
 <script src="../site_libs/quarto-contrib/iconify-2.1.0/iconify-icon.min.js"></script>
 <script id="quarto-search-options" type="application/json">{
   "location": "navbar",
@@ -132,9 +132,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
     }
   })
   </script>
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TC329HJ');</script>
-<!-- End Google Tag Manager -->
+
 <link href="https://iosevka-webfonts.github.io/iosevkatermss15/IosevkaTermSS15.css" rel="stylesheet">
 
   <script>window.backupDefine = window.define; window.define = undefined;</script><script src="https://cdn.jsdelivr.net/npm/katex@latest/dist/katex.min.js"></script>
@@ -382,7 +380,16 @@ window.Quarto = {
 </tr>
 </thead>
 <tbody class="list">
-<tr data-index="0" data-listing-date-sort="1734933600000" data-listing-file-modified-sort="1737954546503" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="🎤 is this thing on?" data-listing-filename-sort="index.qmd" onclick="href = this.querySelector('a').getAttribute('href');
+<tr data-index="0" data-listing-date-sort="1741928400000" data-listing-file-modified-sort="1742707202879" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="5" data-listing-word-count-sort="829" data-listing-title-sort="🤖 on ai" data-listing-filename-sort="index.qmd" onclick="href = this.querySelector('a').getAttribute('href');
+ if (href) { window.location=href ; return false; }">
+<td>
+<a href="../posts/on-ai/index.html" class="title listing-title">🤖 on ai</a>
+</td>
+<td>
+<span class="listing-date">2025-03-14</span>
+</td>
+</tr>
+<tr data-index="1" data-listing-date-sort="1734933600000" data-listing-file-modified-sort="1738347032397" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="🎤 is this thing on?" data-listing-filename-sort="index.qmd" onclick="href = this.querySelector('a').getAttribute('href');
  if (href) { window.location=href ; return false; }">
 <td>
 <a href="../posts/is-this-thing-on/index.html" class="title listing-title">🎤 is this thing on?</a>
@@ -1043,16 +1050,17 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
 <span id="cb1-19"><a href="#cb1-19"></a><span class="co">      title: "&lt;b&gt;what&lt;/b&gt;"</span></span>
 <span id="cb1-20"><a href="#cb1-20"></a><span class="co">  contents:</span></span>
 <span id="cb1-21"><a href="#cb1-21"></a><span class="co">    - "../posts/is-this-thing-on/index.qmd"</span></span>
-<span id="cb1-22"><a href="#cb1-22"></a><span class="co">---</span></span>
-<span id="cb1-23"><a href="#cb1-23"></a></span>
-<span id="cb1-24"><a href="#cb1-24"></a><span class="fu">## musings of a genius</span></span>
-<span id="cb1-25"><a href="#cb1-25"></a></span>
-<span id="cb1-26"><a href="#cb1-26"></a>:::: {.feature}</span>
-<span id="cb1-27"><a href="#cb1-27"></a></span>
-<span id="cb1-28"><a href="#cb1-28"></a>::: {#listing-posts}</span>
-<span id="cb1-29"><a href="#cb1-29"></a>:::</span>
-<span id="cb1-30"><a href="#cb1-30"></a></span>
-<span id="cb1-31"><a href="#cb1-31"></a>::::</span></code><button title="Copy to Clipboard" class="code-copy-button" data-in-quarto-modal=""><i class="bi"></i></button></pre></div>
+<span id="cb1-22"><a href="#cb1-22"></a><span class="co">    - "../posts/on-ai/index.qmd"</span></span>
+<span id="cb1-23"><a href="#cb1-23"></a><span class="co">---</span></span>
+<span id="cb1-24"><a href="#cb1-24"></a></span>
+<span id="cb1-25"><a href="#cb1-25"></a><span class="fu">## musings of a genius</span></span>
+<span id="cb1-26"><a href="#cb1-26"></a></span>
+<span id="cb1-27"><a href="#cb1-27"></a>:::: {.feature}</span>
+<span id="cb1-28"><a href="#cb1-28"></a></span>
+<span id="cb1-29"><a href="#cb1-29"></a>::: {#listing-posts}</span>
+<span id="cb1-30"><a href="#cb1-30"></a>:::</span>
+<span id="cb1-31"><a href="#cb1-31"></a></span>
+<span id="cb1-32"><a href="#cb1-32"></a>::::</span></code><button title="Copy to Clipboard" class="code-copy-button" data-in-quarto-modal=""><i class="bi"></i></button></pre></div>
 </div></div></div></div></div>
 </div> <!-- /content -->
 

--- a/docs/qmd/projects/index.html
+++ b/docs/qmd/projects/index.html
@@ -73,8 +73,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <link href="../../site_libs/quarto-html/tippy.css" rel="stylesheet">
 <script src="../../site_libs/bootstrap/bootstrap.min.js"></script>
 <link href="../../site_libs/bootstrap/bootstrap-icons.css" rel="stylesheet">
-<link href="../../site_libs/bootstrap/bootstrap-634274a65c934703ca25721b58038b96.min.css" rel="stylesheet" append-hash="true" class="quarto-color-scheme" id="quarto-bootstrap" data-mode="light">
-<link href="../../site_libs/bootstrap/bootstrap-dark-375d3df8afcba5abed17207adbcd21f6.min.css" rel="prefetch" append-hash="true" class="quarto-color-scheme quarto-color-alternate" id="quarto-bootstrap" data-mode="dark">
+<link href="../../site_libs/bootstrap/bootstrap-d2106b212eb76b55cd8cda3724386f96.min.css" rel="stylesheet" append-hash="true" class="quarto-color-scheme" id="quarto-bootstrap" data-mode="light">
+<link href="../../site_libs/bootstrap/bootstrap-dark-cc2076eef7a103a60f2d4c6c3c1e31d6.min.css" rel="prefetch" append-hash="true" class="quarto-color-scheme quarto-color-alternate" id="quarto-bootstrap" data-mode="dark">
 <script src="../../site_libs/quarto-contrib/iconify-2.1.0/iconify-icon.min.js"></script>
 <script id="quarto-search-options" type="application/json">{
   "location": "navbar",
@@ -101,9 +101,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
     "search-label": "Search"
   }
 }</script>
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TC329HJ');</script>
-<!-- End Google Tag Manager -->
+
 <link href="https://iosevka-webfonts.github.io/iosevkatermss15/IosevkaTermSS15.css" rel="stylesheet">
 
 
@@ -292,26 +290,253 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </header>
 
 
-<div class="callout callout-style-simple callout-tip no-icon callout-titled" aria-title="GitHub Repos" title="[📂 [`ishanpragada/`](https://github.com/saforem2?tab=repositories)]{.dim-text-11}" style="text-align: left!important; width:100%; background-color:rgba(131,131,131,0.05)!important; border: 1px solid rgba(131,131,131,0.3)!important; opacity:100%;">
+<div class="callout callout-style-simple callout-tip no-icon callout-titled" aria-title="GitHub Repos" title="[📂 [`ishanpragada/`](https://github.com/ishanpragada?tab=repositories)]{.dim-text-11}" style="text-align: left!important; width:100%; background-color:rgba(131,131,131,0.05)!important; border: 1px solid rgba(131,131,131,0.3)!important; opacity:100%;">
 <div class="callout-header d-flex align-content-center" data-bs-toggle="collapse" data-bs-target=".callout-1-contents" aria-controls="callout-1" aria-expanded="true" aria-label="Toggle callout">
 <div class="callout-icon-container">
 <i class="callout-icon no-icon"></i>
 </div>
 <div class="callout-title-container flex-fill">
-<span class="dim-text-11">📂 <a href="https://github.com/saforem2?tab=repositories"><code>ishanpragada/</code></a></span>
+<span class="dim-text-11">📂 <a href="https://github.com/ishanpragada?tab=repositories"><code>ishanpragada/</code></a></span>
 </div>
 <div class="callout-btn-toggle d-inline-block border-0 py-1 ps-1 pe-0 float-end"><i class="callout-toggle"></i></div>
 </div>
 <div id="callout-1" class="callout-1-contents callout-collapse collapse show">
 <div class="callout-body-container callout-body">
-<div class="flex-container" style="flex-flow: wrap;">
-<p><a href="https://github.com/appfl/appfl"><img src="https://github-readme-stats.vercel.app/api/pin/?username=appfl&amp;repo=appfl&amp;theme=transparent&amp;include_all_commits=true&amp;hide_border=true&amp;line_height=5&amp;card_width=300px&amp;text_color=838383&amp;title_color=838383.svg" class="img-fluid"></a></p>
-<p><a href="https://github.com/ishanpragada/dlp_model"><img src="https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&amp;repo=dlp_model&amp;theme=transparent&amp;include_all_commits=true&amp;hide_border=true&amp;line_height=5&amp;card_width=300px&amp;text_color=838383&amp;title_color=838383.svg" class="img-fluid"></a></p>
-<p><a href="https://github.com/ishanpragada/asr_system"><img src="https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&amp;repo=asr_system&amp;theme=transparent&amp;include_all_commits=true&amp;hide_border=true&amp;line_height=5&amp;card_width=300px&amp;text_color=838383&amp;title_color=838383.svg" class="img-fluid"></a></p>
-<p><a href="https://github.com/ishanpragada/alexa_gpt"><img src="https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&amp;repo=alexa_gpt&amp;theme=transparent&amp;include_all_commits=true&amp;hide_border=true&amp;line_height=5&amp;card_width=300px&amp;text_color=838383&amp;title_color=838383.svg" class="img-fluid"></a></p>
-<p><a href="https://github.com/ishanpragada/ragaID"><img src="https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&amp;repo=ragaID&amp;theme=transparent&amp;include_all_commits=true&amp;hide_border=true&amp;line_height=5&amp;card_width=300px&amp;text_color=838383&amp;title_color=838383.svg" class="img-fluid"></a></p>
-<p><a href="https://github.com/ishanpragada/portfolio_website"><img src="https://github-readme-stats.vercel.app/api/pin/?username=ishanpragada&amp;repo=portfolio_website&amp;theme=transparent&amp;include_all_commits=true&amp;hide_border=true&amp;line_height=5&amp;card_width=300px&amp;text_color=838383&amp;title_color=838383.svg" class="img-fluid"></a></p>
+<style>
+  .repo-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 0.5rem;
+    padding-bottom: 0;
+  }
+
+  /* invisible spacer prevents the lone last card from stretching */
+  .repo-grid::after {
+    content: "";
+    flex: 1 1 260px;
+    max-width: 360px;
+    height: 0;
+    overflow: hidden;
+  }
+
+  .repo-card {
+    flex: 1 1 260px;
+    max-width: 360px;
+    border-radius: 0pt;
+    padding: 1rem 1.1rem 1.5rem;
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    background-color: var(--bs-body-bg, #ffffff);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.15s ease, box-shadow 0.15s ease,
+                border-color 0.15s ease, background-color 0.15s ease;
+    font-family: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
+  }
+
+  .repo-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 3pt 3pt #AE81FF;
+  }
+
+  .repo-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.4rem;
+    margin-bottom: 0.35rem;
+  }
+
+  .repo-name {
+    color: inherit;
+    background: none;
+    font-size: 1.0rem;
+    font-weight: 600;
+    margin: 0;
+    word-break: break-word;
+    border: 1pt solid rgba(0,0,0,0.0) !important;
+    padding-inline: 1pt;
+  }
+
+  .repo-name a {
+    text-decoration: none;
+    color: var(--bs-link-color, #0d6efd);
+  }
+
+  .repo-name a:hover {
+    text-decoration: underline;
+    border: none;
+  }
+
+  .repo-badge {
+    font-size: 0.7rem;
+    padding: 0.15rem 0.45rem;
+    border: 1px solid var(--bs-border-color, #838383);
+    background: var(--bs-secondary-bg, rgba(108, 117, 125, 0.1));
+    white-space: nowrap;
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  .repo-description {
+    font-size: 0.9rem;
+    margin: 0.3rem 0 0.6rem;
+    color: var(--bs-secondary-color, #6c757d);
+    min-height: 2.2em;
+  }
+
+  .repo-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: auto;
+    font-size: 0.8rem;
+    color: var(--bs-secondary-color, #6c757d);
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  .repo-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+  }
+
+  .repo-language-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    background: currentColor;
+  }
+
+  body.quarto-dark .repo-card {
+    background-color: var(--bs-body-bg, #1c1c1c);
+    border-color: var(--bs-border-color, #374151);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.6);
+  }
+
+  body.quarto-dark .repo-card:hover {
+    box-shadow: 3pt 3pt var(--bs-secondary-color, #838383);
+  }
+
+  body.quarto-dark .repo-badge {
+    background: #2a2a2a !important;
+    color: #f0f0f0 !important;
+    border-color: #555555 !important;
+  }
+
+  .repo-grid-loading {
+    font-size: 0.9rem;
+    color: var(--bs-secondary-color, #6c757d);
+    margin-top: 0.75rem;
+    font-family: "IBM Plex Mono", monospace;
+  }
+</style>
+<p class="repo-grid-loading" id="repo-grid-status">
+Loading repositories from GitHub…
+</p>
+<div id="repo-grid" class="repo-grid" data-github-user="ishanpragada">
+
 </div>
+<script>
+  (async function () {
+    const grid = document.getElementById("repo-grid");
+    const status = document.getElementById("repo-grid-status");
+    if (!grid) return;
+
+    const username = grid.getAttribute("data-github-user") || "ishanpragada";
+    const apiUrl = `https://api.github.com/users/${username}/repos?per_page=100&sort=updated`;
+
+    try {
+      const res = await fetch(apiUrl);
+      if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
+      const repos = await res.json();
+
+      const filtered = repos.filter(r => !r.fork);
+
+      if (filtered.length === 0) {
+        if (status) status.textContent = "No repositories found.";
+        return;
+      }
+      if (status) status.remove();
+
+      function formatNumber(n) {
+        if (n >= 1_000_000) return (n / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
+        if (n >= 1_000) return (n / 1_000).toFixed(1).replace(/\.0$/, "") + "k";
+        return String(n);
+      }
+
+      filtered.forEach(repo => {
+        const card = document.createElement("div");
+        card.className = "repo-card";
+
+        const header = document.createElement("div");
+        header.className = "repo-header";
+
+        const title = document.createElement("h3");
+        title.className = "repo-name";
+        const link = document.createElement("a");
+        link.href = repo.html_url;
+        link.textContent = repo.name;
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
+        title.appendChild(link);
+
+        const badge = document.createElement("span");
+        badge.className = "repo-badge";
+        badge.textContent = repo.private ? "Private" : "Public";
+
+        header.appendChild(title);
+        header.appendChild(badge);
+
+        const desc = document.createElement("p");
+        desc.className = "repo-description";
+        desc.textContent = repo.description || "No description provided.";
+
+        const meta = document.createElement("div");
+        meta.className = "repo-meta";
+
+        if (repo.language) {
+          const langSpan = document.createElement("span");
+          const dot = document.createElement("span");
+          dot.className = "repo-language-dot";
+          langSpan.appendChild(dot);
+          const langText = document.createElement("span");
+          langText.textContent = repo.language;
+          langSpan.appendChild(langText);
+          meta.appendChild(langSpan);
+        }
+
+        const starsSpan = document.createElement("span");
+        starsSpan.innerHTML = "⭐️ " + formatNumber(repo.stargazers_count || 0);
+        meta.appendChild(starsSpan);
+
+        const updatedSpan = document.createElement("span");
+        const updatedDate = new Date(repo.updated_at);
+        updatedSpan.textContent = "Updated " + updatedDate.toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric"
+        });
+        meta.appendChild(updatedSpan);
+
+        card.appendChild(header);
+        card.appendChild(desc);
+        card.appendChild(meta);
+        grid.appendChild(card);
+      });
+
+      // Force bottom spacing via inline styles (bypasses CSS specificity issues)
+      grid.style.paddingBottom = "0.25rem";
+      const lastCard = grid.querySelector(".repo-card:last-child");
+      if (lastCard) lastCard.style.paddingBottom = "1.5rem";
+    } catch (err) {
+      console.error(err);
+      if (status) {
+        status.textContent = "Failed to load repositories from GitHub.";
+      }
+    }
+  })();
+</script>
 </div>
 </div>
 </div>

--- a/docs/search.json
+++ b/docs/search.json
@@ -4,21 +4,7 @@
     "href": "qmd/projects/index.html",
     "title": "📦 projects",
     "section": "",
-    "text": "📂 ishanpragada/"
-  },
-  {
-    "objectID": "posts/index.html#musings-of-a-genius",
-    "href": "posts/index.html#musings-of-a-genius",
-    "title": "📬 posts",
-    "section": "musings of a genius",
-    "text": "musings of a genius\n\n\n\n\n\n\nwhat\n\n\nwhen\n\n\n\n\n\n\n🎤 is this thing on?\n\n\n2024-12-23\n\n\n\n\n\nNo matching items"
-  },
-  {
-    "objectID": "index.html",
-    "href": "index.html",
-    "title": "Ishan's Portfolio",
-    "section": "",
-    "text": "👋 hi, i’m ishan!\n\n     \n\n\n\n🧑🏻‍💻 about📦 projects🪖 experience🎶 music\n\n\n\n\n\ncomputer science student @ UIUC\ncurrently interested in:\n\nbuilding sustainable solutions to everyday problems using disruptive technologies.\nidentifying and addressing health infodemics.\n\n\n\n\n\n\n\n\n\n\n🔧 recent work\n\n\n\n\n\nworking on adding comments to my blog posts…\n\n\n\n\n\n\n\n\n\n now playing\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n📷 gallery\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n© Copyright Ishan Buyyanapragada\n\n\n\n\n\n\n\n\n\n\n\n\n\n📂 ishanpragada/\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n👔 employment\n\n\n\nTable 1: 💻 work\n\n\n\n\n\n\nposition\n@\nstart\nend\n\n\n\n\nsoftware engineering intern\nANB Systems\n2024\n–\n\n\nsoftware developer\nDisruption Lab\n2024\n–\n\n\nresearch intern\nALCF\n2023\n2024\n\n\nCELS research assistant\nANL\n2021\n2023\n\n\n\n\n\n\n\n\n\n🍎 school\n\n\n\nTable 2: 🎓 education\n\n\n\n\n\n\ndegree\nin\n@\nend\n\n\n\n\nB.Sc\nComputer Science\nUIUC\n2027"
+    "text": "📂 ishanpragada/\n\n\n\n\n\n\n\nLoading repositories from GitHub…"
   },
   {
     "objectID": "posts/is-this-thing-on/index.html",
@@ -26,5 +12,61 @@
     "title": "🎤 is this thing on?",
     "section": "",
     "text": "yes. (this is a test blog)"
+  },
+  {
+    "objectID": "index.html",
+    "href": "index.html",
+    "title": "Ishan's Portfolio",
+    "section": "",
+    "text": "👋 hi, i’m ishan!\n\n     \n\n\n\n🧑🏻‍💻 about📦 projects🪖 experience🎶 music\n\n\n\n\n\nincoming sde intern @ AWS · cs @ UIUC\ncurrently interested in:\n\nsystems programming, performance engineering, and low-latency execution on Linux.\nidentifying and addressing health infodemics.\n\n\n\n\n\n\n\n\n\n\n🔧 recent work\n\n\n\n\n\nworking on adding comments to my blog posts…\n\n\n\n\n\n\n\n\n\n now playing\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n📷 gallery\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n© Copyright Ishan Buyyanapragada\n\n\n\n\n\n\n\n\n\n\n\n\n\n📂 ishanpragada/\n\n\n\n\n\n\n\nLoading repositories from GitHub…\n\n\n\n\n\n\n\n\n\n\n\n\n👔 employment\n\n\n\nTable 1: 💻 work\n\n\n\n\n\n\nposition\n@\nstart\nend\n\n\n\n\nsoftware development engineering intern\nAmazon Web Services\n2026\n–\n\n\nsystems operations engineer\nTandemn\n2025\n–\n\n\nSPIN intern\nNCSA\n2025\n2025\n\n\nsoftware engineering intern\nANB Systems\n2024\n2024\n\n\nCELS research intern\nANL\n2022\n2024\n\n\n\n\n\n\n\n\n\n🍎 school\n\n\n\nTable 2: 🎓 education\n\n\n\n\n\n\ndegree\nin\n@\nend\n\n\n\n\nB.Sc (James Scholar)\nComputer Science\nUIUC\n2028"
+  },
+  {
+    "objectID": "posts/index.html#musings-of-a-genius",
+    "href": "posts/index.html#musings-of-a-genius",
+    "title": "📬 posts",
+    "section": "musings of a genius",
+    "text": "musings of a genius\n\n\n\n\n\n\nwhat\n\n\nwhen\n\n\n\n\n\n\n🤖 on ai\n\n\n2025-03-14\n\n\n\n\n🎤 is this thing on?\n\n\n2024-12-23\n\n\n\n\n\nNo matching items"
+  },
+  {
+    "objectID": "posts/on-ai/index.html#quick-context",
+    "href": "posts/on-ai/index.html#quick-context",
+    "title": "🤖 on ai",
+    "section": "quick context",
+    "text": "quick context\nHi, I’m Ishan. I’m in my spring break of freshman year right now, so not even a fifth of the way through my computer science degree. That isn’t to say that I’m having a tough time here. In fact, it’s quite the opposite, and that’s what I’m here to address."
+  },
+  {
+    "objectID": "posts/on-ai/index.html#my-problem",
+    "href": "posts/on-ai/index.html#my-problem",
+    "title": "🤖 on ai",
+    "section": "(my) problem",
+    "text": "(my) problem\nSince the beginning of college—possibly earlier—I’ve been growing increasingly impatient. Specifically when it comes to thinking programmtically. I can’t be bothered to spend hours debugging an issue, or even figuring out the correct way to approach it. Forget coding: I can’t even spend time understanding fundamental concepts that are being taught in my classes. I’ve been trying to come up with a euphemism for my plight, but that would be doing it injustice.\n\nI’ve become a glorified prompt engineer. 1\n\nI mean come on, it’s so simple. Stuck on a problem? Just GPT it. Didn’t work? Did you try Claude? Gemini? Grok? Deepseek? Copilot? …and on and on. It’s become increasingly uncommon to think: to look at what’s in front of you and try to figure something out yourself. Instead, we prefer to learn by recieving information in brief, matter-of-fact responses from large language models that use up tons of water to stay cool. 2\nIt became all the more apparent at a hackathon I attended a few weeks back. 3 The lack of time to build a project exacerbates the dependence on AI, almost to the a point where it turns into a contest for “Who Can Prompt Their AIs the Best?” It’s not at all surprising—why should I rely on my own flawed human knowledge when I have an much faster answer available at a button’s reach?\nI’m not here to dismiss the profound beneficial impacts artificial intelligence can have on education, but I am here to try and remove its hand in turning me into an over-reliant and lazy learner."
+  },
+  {
+    "objectID": "posts/on-ai/index.html#my-attempts-at-a-solution",
+    "href": "posts/on-ai/index.html#my-attempts-at-a-solution",
+    "title": "🤖 on ai",
+    "section": "(my) attempts at a solution",
+    "text": "(my) attempts at a solution\nAt first, the problem sounds fairly easy to fix. Just stop using AI! Restrict the websites on your browser if you have to. Embrace the pre-AI methods of googling and perusing until you find a solution to your problem.\nI actually tried this strategy for the weeks leading up to spring break. I made it a point to avoid AI-use as much as possible on assignments (even for “guidance” or whatever else I used to tell myself to make it sound better in my head). I was back on StackOverflow, decrypting answers and how they could be applied to my specific problem. By the end of it, I was assuredly a smarter man. However, I was also a significantly slower one.\nAssignments that would usually take me hours began taking weeks. I would have to block out large chunks of my day to work on projects that used be an afterthought. I realized that—in essense—AI has provided us unprecedented efficiency at the cost of foundational knowledge."
+  },
+  {
+    "objectID": "posts/on-ai/index.html#building-a-actual-solution",
+    "href": "posts/on-ai/index.html#building-a-actual-solution",
+    "title": "🤖 on ai",
+    "section": "building a actual solution",
+    "text": "building a actual solution\nSo I came up with a list of things that this project would need to do:\n\n\n\n\n\n\n📝 checklist\n\n\n\n\n\n\nstops unnecessary and lazy ai usage (i.e. copy pasting code and/or asking for solutions)\nguides me down a better, more educational path that forces me to think on my own (with some help)\npreserves hardcore learning and efficiency as much as possible 4\noptional: multiple levels of scrutiny depending on the situation\n\n\n\n\nI settled on a Chrome extension that can monitor the way I’m using AI. It’s kinda like the ones that keep you on task, but this one is specifically to minimize lazy usage of AI for assignments. However I also wanted it to be as unbothersome as possible (I don’t wanna explain every move I take for the extension’s approval). In addition, it should gameify the process a little and reward thoughtful prompts as opposed to unhelpful ones.\nIt would be quite hypocritical of me to use AI to build this in a day or so, so it looks like I know what I’ll be doing for most of my spring break."
+  },
+  {
+    "objectID": "posts/on-ai/index.html#final-product-thinkfirst",
+    "href": "posts/on-ai/index.html#final-product-thinkfirst",
+    "title": "🤖 on ai",
+    "section": "final product: ThinkFirst",
+    "text": "final product: ThinkFirst\nIt’s a extension that encourages critical thinking and mitigates lazy AI usage. Here’s a quick demo:"
+  },
+  {
+    "objectID": "posts/on-ai/index.html#footnotes",
+    "href": "posts/on-ai/index.html#footnotes",
+    "title": "🤖 on ai",
+    "section": "Footnotes",
+    "text": "Footnotes\n\n\ni’m not trying to disrespect any prompt engineers out there, but in my case it’s not a good thing to be right now.↩︎\nkind of a tangent but there’s an undeniable parallel between the general shift to short-form media (tiktoks, reels, etc.) and our preference for short LLM blurbs that get us exactly what we want.↩︎\ndespite my qualms above, hackillinois itself was extremely fun. you can check out our second-place-winning project here.↩︎\nobviously this would make me more ineffecient at coding, so i can’t expect it to be up to par with someone who’s prompting their way through an assignment. however, i’m hoping to strike a good balance between learning what i’m doing and being able to do it reasonably fast.↩︎"
   }
 ]

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -5,15 +5,19 @@
     <lastmod>2025-01-26T23:16:48.770Z</lastmod>
   </url>
   <url>
-    <loc>https://ishankr.com/posts/index.html</loc>
-    <lastmod>2025-01-27T05:42:38.514Z</lastmod>
+    <loc>https://ishankr.com/posts/is-this-thing-on/index.html</loc>
+    <lastmod>2025-01-31T18:10:32.397Z</lastmod>
   </url>
   <url>
     <loc>https://ishankr.com/index.html</loc>
-    <lastmod>2025-01-27T05:49:19.268Z</lastmod>
+    <lastmod>2026-04-02T22:18:10.752Z</lastmod>
   </url>
   <url>
-    <loc>https://ishankr.com/posts/is-this-thing-on/index.html</loc>
-    <lastmod>2025-01-27T05:09:06.503Z</lastmod>
+    <loc>https://ishankr.com/posts/index.html</loc>
+    <lastmod>2026-04-04T18:47:47.907Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ishankr.com/posts/on-ai/index.html</loc>
+    <lastmod>2025-03-23T05:20:02.879Z</lastmod>
   </url>
 </urlset>

--- a/qmd/partials/_projects.qmd
+++ b/qmd/partials/_projects.qmd
@@ -1,17 +1,243 @@
 
 ::: {.callout-tip icon=false aria-title="GitHub Repos" title='[📂 [`ishanpragada/`](https://github.com/ishanpragada?tab=repositories)]{.dim-text-11}' collapse="false" style="text-align: left!important; width:100%; background-color:rgba(131,131,131,0.05)!important; border: 1px solid rgba(131,131,131,0.3)!important; opacity:100%;"}
 
-::: {.flex-container style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;"}
+<style>
+  .repo-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 0.5rem;
+    padding-bottom: 0;
+  }
 
-[![](https://gh-card.dev/repos/ishanpragada/dlp_model.svg?theme=dark)](https://github.com/ishanpragada/dlp_model)
+  /* invisible spacer prevents the lone last card from stretching */
+  .repo-grid::after {
+    content: "";
+    flex: 1 1 260px;
+    max-width: 360px;
+    height: 0;
+    overflow: hidden;
+  }
 
-[![](https://gh-card.dev/repos/ishanpragada/asr_system.svg?theme=dark)](https://github.com/ishanpragada/asr_system)
+  .repo-card {
+    flex: 1 1 260px;
+    max-width: 360px;
+    border-radius: 0pt;
+    padding: 1rem 1.1rem 1.5rem;
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    background-color: var(--bs-body-bg, #ffffff);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.15s ease, box-shadow 0.15s ease,
+                border-color 0.15s ease, background-color 0.15s ease;
+    font-family: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
+  }
 
-[![](https://gh-card.dev/repos/ishanpragada/alexa_gpt.svg?theme=dark)](https://github.com/ishanpragada/alexa_gpt)
+  .repo-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 3pt 3pt #AE81FF;
+  }
 
-[![](https://gh-card.dev/repos/ishanpragada/ragaID.svg?theme=dark)](https://github.com/ishanpragada/ragaID)
+  .repo-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.4rem;
+    margin-bottom: 0.35rem;
+  }
 
-[![](https://gh-card.dev/repos/ishanpragada/portfolio_website.svg?theme=dark)](https://github.com/ishanpragada/portfolio_website)
-:::
+  .repo-name {
+    color: inherit;
+    background: none;
+    font-size: 1.0rem;
+    font-weight: 600;
+    margin: 0;
+    word-break: break-word;
+    border: 1pt solid rgba(0,0,0,0.0) !important;
+    padding-inline: 1pt;
+  }
+
+  .repo-name a {
+    text-decoration: none;
+    color: var(--bs-link-color, #0d6efd);
+  }
+
+  .repo-name a:hover {
+    text-decoration: underline;
+    border: none;
+  }
+
+  .repo-badge {
+    font-size: 0.7rem;
+    padding: 0.15rem 0.45rem;
+    border: 1px solid var(--bs-border-color, #838383);
+    background: var(--bs-secondary-bg, rgba(108, 117, 125, 0.1));
+    white-space: nowrap;
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  .repo-description {
+    font-size: 0.9rem;
+    margin: 0.3rem 0 0.6rem;
+    color: var(--bs-secondary-color, #6c757d);
+    min-height: 2.2em;
+  }
+
+  .repo-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: auto;
+    font-size: 0.8rem;
+    color: var(--bs-secondary-color, #6c757d);
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  .repo-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+  }
+
+  .repo-language-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    background: currentColor;
+  }
+
+  body.quarto-dark .repo-card {
+    background-color: var(--bs-body-bg, #1c1c1c);
+    border-color: var(--bs-border-color, #374151);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.6);
+  }
+
+  body.quarto-dark .repo-card:hover {
+    box-shadow: 3pt 3pt var(--bs-secondary-color, #838383);
+  }
+
+  body.quarto-dark .repo-badge {
+    background: #2a2a2a !important;
+    color: #f0f0f0 !important;
+    border-color: #555555 !important;
+  }
+
+  .repo-grid-loading {
+    font-size: 0.9rem;
+    color: var(--bs-secondary-color, #6c757d);
+    margin-top: 0.75rem;
+    font-family: "IBM Plex Mono", monospace;
+  }
+</style>
+
+<p class="repo-grid-loading" id="repo-grid-status">
+  Loading repositories from GitHub…
+</p>
+<div id="repo-grid"
+     class="repo-grid"
+     data-github-user="ishanpragada">
+</div>
+
+<script>
+  (async function () {
+    const grid = document.getElementById("repo-grid");
+    const status = document.getElementById("repo-grid-status");
+    if (!grid) return;
+
+    const username = grid.getAttribute("data-github-user") || "ishanpragada";
+    const apiUrl = `https://api.github.com/users/${username}/repos?per_page=100&sort=updated`;
+
+    try {
+      const res = await fetch(apiUrl);
+      if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
+      const repos = await res.json();
+
+      const filtered = repos.filter(r => !r.fork);
+
+      if (filtered.length === 0) {
+        if (status) status.textContent = "No repositories found.";
+        return;
+      }
+      if (status) status.remove();
+
+      function formatNumber(n) {
+        if (n >= 1_000_000) return (n / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
+        if (n >= 1_000) return (n / 1_000).toFixed(1).replace(/\.0$/, "") + "k";
+        return String(n);
+      }
+
+      filtered.forEach(repo => {
+        const card = document.createElement("div");
+        card.className = "repo-card";
+
+        const header = document.createElement("div");
+        header.className = "repo-header";
+
+        const title = document.createElement("h3");
+        title.className = "repo-name";
+        const link = document.createElement("a");
+        link.href = repo.html_url;
+        link.textContent = repo.name;
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
+        title.appendChild(link);
+
+        const badge = document.createElement("span");
+        badge.className = "repo-badge";
+        badge.textContent = repo.private ? "Private" : "Public";
+
+        header.appendChild(title);
+        header.appendChild(badge);
+
+        const desc = document.createElement("p");
+        desc.className = "repo-description";
+        desc.textContent = repo.description || "No description provided.";
+
+        const meta = document.createElement("div");
+        meta.className = "repo-meta";
+
+        if (repo.language) {
+          const langSpan = document.createElement("span");
+          const dot = document.createElement("span");
+          dot.className = "repo-language-dot";
+          langSpan.appendChild(dot);
+          const langText = document.createElement("span");
+          langText.textContent = repo.language;
+          langSpan.appendChild(langText);
+          meta.appendChild(langSpan);
+        }
+
+        const starsSpan = document.createElement("span");
+        starsSpan.innerHTML = "⭐️ " + formatNumber(repo.stargazers_count || 0);
+        meta.appendChild(starsSpan);
+
+        const updatedSpan = document.createElement("span");
+        const updatedDate = new Date(repo.updated_at);
+        updatedSpan.textContent = "Updated " + updatedDate.toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric"
+        });
+        meta.appendChild(updatedSpan);
+
+        card.appendChild(header);
+        card.appendChild(desc);
+        card.appendChild(meta);
+        grid.appendChild(card);
+      });
+
+      // Force bottom spacing via inline styles (bypasses CSS specificity issues)
+      grid.style.paddingBottom = "0.25rem";
+      const lastCard = grid.querySelector(".repo-card:last-child");
+      if (lastCard) lastCard.style.paddingBottom = "1.5rem";
+    } catch (err) {
+      console.error(err);
+      if (status) {
+        status.textContent = "Failed to load repositories from GitHub.";
+      }
+    }
+  })();
+</script>
 
 :::

--- a/qmd/partials/_projects.qmd
+++ b/qmd/partials/_projects.qmd
@@ -1,17 +1,17 @@
 
 ::: {.callout-tip icon=false aria-title="GitHub Repos" title='[📂 [`ishanpragada/`](https://github.com/ishanpragada?tab=repositories)]{.dim-text-11}' collapse="false" style="text-align: left!important; width:100%; background-color:rgba(131,131,131,0.05)!important; border: 1px solid rgba(131,131,131,0.3)!important; opacity:100%;"}
 
-::: {.flex-container style="flex-flow: wrap;"}
+::: {.flex-container style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;"}
 
-[![](https://gh-card.dev/repos/ishanpragada/dlp_model.svg)](https://github.com/ishanpragada/dlp_model)
+[![](https://gh-card.dev/repos/ishanpragada/dlp_model.svg?theme=dark)](https://github.com/ishanpragada/dlp_model)
 
-[![](https://gh-card.dev/repos/ishanpragada/asr_system.svg)](https://github.com/ishanpragada/asr_system)
+[![](https://gh-card.dev/repos/ishanpragada/asr_system.svg?theme=dark)](https://github.com/ishanpragada/asr_system)
 
-[![](https://gh-card.dev/repos/ishanpragada/alexa_gpt.svg)](https://github.com/ishanpragada/alexa_gpt)
+[![](https://gh-card.dev/repos/ishanpragada/alexa_gpt.svg?theme=dark)](https://github.com/ishanpragada/alexa_gpt)
 
-[![](https://gh-card.dev/repos/ishanpragada/ragaID.svg)](https://github.com/ishanpragada/ragaID)
+[![](https://gh-card.dev/repos/ishanpragada/ragaID.svg?theme=dark)](https://github.com/ishanpragada/ragaID)
 
-[![](https://gh-card.dev/repos/ishanpragada/portfolio_website.svg)](https://github.com/ishanpragada/portfolio_website)
+[![](https://gh-card.dev/repos/ishanpragada/portfolio_website.svg?theme=dark)](https://github.com/ishanpragada/portfolio_website)
 :::
 
 :::


### PR DESCRIPTION
## Summary

- Replaces static `gh-card.dev` image cards with a live GitHub API-powered flex grid
- Cards show repo name (linked), Public/Private badge, description, language dot, star count, and last updated date
- Hover effect: `translateY(-3px)` lift + purple (`#AE81FF`) box shadow matching site theme
- Dark mode via `body.quarto-dark` selector: dark card backgrounds, dark badge with white text
- Callout-tip wrapper styled to match existing site conventions (`dim-text-11`, translucent border)
- Last card prevents row-stretching via flexbox `::after` spacer trick
- Bottom spacing on last card applied via JS inline styles to bypass CSS specificity issues

## Test plan

- [ ] Check home page **📦 projects** tab in light and dark mode
- [ ] Check `/qmd/projects/` page in light and dark mode
- [ ] Verify last card doesn't stretch to fill row
- [ ] Verify hover shadow is purple
- [ ] Verify Public badge is dark with white text in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)