### PR TITLE
update homepage tagline to open source @ nvidia

### DIFF
--- a/about/_about.qmd
+++ b/about/_about.qmd
@@ -2,7 +2,7 @@
 
 ::: {.column}
 
-- incoming sde intern @ [AWS](https://aws.amazon.com/) · cs @ [UIUC](https://illinois.edu)
+- open source @ [nvidia](https://www.nvidia.com/) · cs @ [UIUC](https://illinois.edu)
 - currently interested in:
     - systems programming, performance engineering, and low-latency execution on Linux.
     - identifying and addressing [health infodemics](https://ischool.illinois.edu/news-events/news/2023/04/virtual-center-addresses-health-infodemics).

--- a/about/_about.qmd
+++ b/about/_about.qmd
@@ -2,7 +2,7 @@
 
 ::: {.column}
 
-- open source @ [nvidia](https://www.nvidia.com/) · cs @ [UIUC](https://illinois.edu)
+- oss @ [nvidia](https://www.nvidia.com/) · cs @ [UIUC](https://illinois.edu)
 - currently interested in:
     - systems programming, performance engineering, and low-latency execution on Linux.
     - identifying and addressing [health infodemics](https://ischool.illinois.edu/news-events/news/2023/04/virtual-center-addresses-health-infodemics).

--- a/about/_experience.qmd
+++ b/about/_experience.qmd
@@ -4,7 +4,7 @@
 ::: {#tbl-experience}
 | position                                                                           |               @                                                    | start | end  |
 |:---------------------------------------------------------------------------------- |:------------------------------------------------------------------:|:-----:|:----:|
-| open source contributor                                                            | [NVIDIA](https://www.nvidia.com/)                                  |  2026 |  --  |
+| oss                                                                               | [NVIDIA](https://www.nvidia.com/)                                  |  2026 |  --  |
 | systems operations engineer                                                        | [Tandemn](https://www.tandemn.com/)                                |  2025 |  --  |
 | SPIN intern                                                                        | [NCSA](https://ncsa.illinois.edu/)                                 |  2025 | 2025 |
 | software engineering intern                                                        | [ANB Systems](https://www.anbsystems.com/)                         |  2024 | 2024 |

--- a/about/_experience.qmd
+++ b/about/_experience.qmd
@@ -4,7 +4,7 @@
 ::: {#tbl-experience}
 | position                                                                           |               @                                                    | start | end  |
 |:---------------------------------------------------------------------------------- |:------------------------------------------------------------------:|:-----:|:----:|
-| software development engineering intern                                            | [Amazon Web Services](https://aws.amazon.com/)                     |  2026 |  --  |
+| open source contributor                                                            | [NVIDIA](https://www.nvidia.com/)                                  |  2026 |  --  |
 | systems operations engineer                                                        | [Tandemn](https://www.tandemn.com/)                                |  2025 |  --  |
 | SPIN intern                                                                        | [NCSA](https://ncsa.illinois.edu/)                                 |  2025 | 2025 |
 | software engineering intern                                                        | [ANB Systems](https://www.anbsystems.com/)                         |  2024 | 2024 |


### PR DESCRIPTION
Changes `incoming sde intern @ AWS` to `open source @ nvidia` on the homepage.